### PR TITLE
Add possibility to handle multiple service monitor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,27 +15,27 @@
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-benchmarks</artifactId>
-            <version>1.11.0</version>
+            <version>1.18.0</version>
         </dependency>
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-okhttp</artifactId>
-            <version>1.11.0</version>
+            <version>1.18.0</version>
         </dependency>
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-testing</artifactId>
-            <version>1.11.0</version>
+            <version>1.18.0</version>
         </dependency>
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-testing</artifactId>
-            <version>1.11.0</version>
+            <version>1.18.0</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>21.0</version>
+            <version>27.1-jre</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>io.prometheus</groupId>
             <artifactId>simpleclient</artifactId>
-            <version>0.3.0</version>
+            <version>0.6.0</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/me/dinowernli/grpc/prometheus/ClientMetrics.java
+++ b/src/main/java/me/dinowernli/grpc/prometheus/ClientMetrics.java
@@ -116,14 +116,17 @@ class ClientMetrics {
 
     Factory(Configuration configuration) {
       CollectorRegistry registry = configuration.getCollectorRegistry();
-      this.rpcStarted = rpcStartedBuilder.register(registry);
-      this.rpcCompleted = rpcCompletedBuilder.register(registry);
-      this.streamMessagesReceived = streamMessagesReceivedBuilder.register(registry);
-      this.streamMessagesSent = streamMessagesSentBuilder.register(registry);
+      String serviceId = configuration.getServiceId().map(id -> "_" + id).orElse("");
+
+      this.rpcStarted = rpcStartedBuilder.namespace("grpc" + serviceId).register(registry);
+      this.rpcCompleted = rpcCompletedBuilder.namespace("grpc" + serviceId).register(registry);
+      this.streamMessagesReceived = streamMessagesReceivedBuilder.namespace("grpc" + serviceId).register(registry);
+      this.streamMessagesSent = streamMessagesSentBuilder.namespace("grpc" + serviceId).register(registry);
 
       if (configuration.isIncludeLatencyHistograms()) {
         this.completedLatencySeconds = Optional.of(ClientMetrics.completedLatencySecondsBuilder
             .buckets(configuration.getLatencyBuckets())
+            .namespace("grpc" + serviceId)
             .register(registry));
       } else {
         this.completedLatencySeconds = Optional.empty();


### PR DESCRIPTION
Add service id in order to be able to monitor multiple grpc services on client side.

Bump grpc version and bump prometheus reporter version